### PR TITLE
Adding EventDataEx output Type

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 ﻿MIT License
 
-Copyright (c) 2019 Alexey Rodionov
+Copyright (c) .NET Foundation. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.EventHubs
 {
@@ -135,14 +136,58 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private static string ConvertEventData2String(EventData x)
             => Encoding.UTF8.GetString(ConvertEventData2Bytes(x));
 
-        private static EventData ConvertBytes2EventData(byte[] input)
-            => new EventData(input);
+        // Default ConvertBytes2EventData convertor was replaced with custom one to add ability to send partitionKey using OOP languages
+        // private static EventData ConvertBytes2EventData(byte[] input)
+        //     => new EventData(input);
 
         private static byte[] ConvertEventData2Bytes(EventData input)
             => input.Body.Array;
 
         private static EventData ConvertString2EventData(string input)
             => ConvertBytes2EventData(Encoding.UTF8.GetBytes(input));
+
+        private static EventData ConvertBytes2EventData(byte[] bytes)
+        {
+            string input = Encoding.UTF8.GetString(bytes);
+
+            if (IsJsonObject(input))
+            {
+                try
+                {
+                    // attempt to parse as an EventDataEx
+                    JObject o = JObject.Parse(input);
+                    var partitionKey = (string)o.GetValue("PartitionKey", StringComparison.OrdinalIgnoreCase)?.Value<string>();
+
+
+                    if (!string.IsNullOrEmpty(partitionKey))
+                    {
+                        byte[] body = o.GetValue("Body", StringComparison.OrdinalIgnoreCase)?.ToObject<byte[]>();
+                        return new EventDataEx(body)
+                        {
+                            PartitionKey = partitionKey
+                        };
+                    }
+                }
+                catch
+                {
+                    // best effort
+                }
+            }
+
+            // return default EventData
+            return new EventData(bytes);
+        }
+
+        private static bool IsJsonObject(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
+            input = input.Trim();
+            return (input.StartsWith("{", StringComparison.OrdinalIgnoreCase) && input.EndsWith("}", StringComparison.OrdinalIgnoreCase));
+        }
 
         private static Task<object> ConvertPocoToEventData(object arg, Attribute attrResolved, ValueBindingContext context)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs
@@ -161,7 +161,17 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
                     if (!string.IsNullOrEmpty(partitionKey))
                     {
-                        byte[] body = o.GetValue("Body", StringComparison.OrdinalIgnoreCase)?.ToObject<byte[]>();
+                        byte[] body;
+                        JToken jToken = o.GetValue("Body", StringComparison.OrdinalIgnoreCase);
+                        if (jToken is JObject)
+                        {
+                            body = Encoding.UTF8.GetBytes(o.GetValue("Body", StringComparison.OrdinalIgnoreCase).ToObject<JObject>().ToString());
+                        }
+                        else
+                        {
+                            body = o.GetValue("Body", StringComparison.OrdinalIgnoreCase)?.ToObject<byte[]>();
+                        }
+
                         return new EventDataEx(body)
                         {
                             PartitionKey = partitionKey

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventDataEx.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventDataEx.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.EventHubs;
+
+namespace Microsoft.Azure.WebJobs.EventHubs
+{
+    /// <summary>
+    /// Extended <see cref="EventData"/> class allowing additional metadata to be
+    /// specified.
+    /// </summary>
+    public class EventDataEx : EventData
+    {
+        public EventDataEx(byte[] array) : base(array) { }
+
+        public EventDataEx(ArraySegment<byte> arraySegment) : base(arraySegment) { }
+
+        /// <summary>
+        /// Gets or sets the partition key that should be used when the
+        /// event is sent.
+        /// </summary>
+        public string PartitionKey { get; set; }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/PublicSurfaceTests.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "EventHubTriggerAttribute",
                 "EventHubOptions",
                 "EventHubWebJobsBuilderExtensions",
-                "EventHubsWebJobsStartup"
+                "EventHubsWebJobsStartup",
+                "EventDataEx"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-eventhubs-extension/pull/18 and issue Azure/azure-sdk-for-net#28245  - a new proposal to replace that PR, which maintains backwards compatibility.