### PR TITLE
Standardize required string testing to not null or white space.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs
@@ -111,8 +111,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 return LogLevel.Information;
             }
 
-            var ehex = ex as EventHubsException;
-            if (!(ex is OperationCanceledException) && (ehex == null || !ehex.IsTransient))
+            if (!(ex is OperationCanceledException) && (!(ex is EventHubsException ehex) || !ehex.IsTransient))
             {
                 // any non-transient exceptions or unknown exception types
                 // we want to log as errors

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubWebJobsBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.EventHubs.Processor;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.EventHubs;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
@@ -17,7 +17,6 @@ using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.EventHubs
 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubsScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubsScaleMonitor.cs
@@ -56,13 +56,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             _client = new Lazy<EventHubClient>(() => EventHubClient.CreateFromConnectionString(ConnectionStringBuilder.ToString()));
         }
 
-        public ScaleMonitorDescriptor Descriptor
-        {
-            get
-            {
-                return _scaleMonitorDescriptor;
-            }
-        }
+        public ScaleMonitorDescriptor Descriptor => _scaleMonitorDescriptor;
 
         private CloudBlobContainer BlobContainer
         {
@@ -94,14 +88,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             }
         }
 
-        async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync()
-        {
-            return await GetMetricsAsync();
-        }
+        async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync() => await GetMetricsAsync();
 
         public async Task<EventHubsTriggerMetrics> GetMetricsAsync()
         {
-            EventHubsTriggerMetrics metrics = new EventHubsTriggerMetrics();
+            var metrics = new EventHubsTriggerMetrics();
             EventHubRuntimeInformation runtimeInfo = null;
 
             try
@@ -152,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             // For each partition, get the last enqueued sequence number.
             // If the last enqueued sequence number does not equal the SequenceNumber from the lease info in storage,
             // accumulate new event counts across partitions to derive total new event counts.
-            List<string> partitionErrors = new List<string>();
+            var partitionErrors = new List<string>();
             for (int i = 0; i < partitionRuntimeInfo.Count; i++)
             {
                 long partitionUnprocessedEventCount = 0;
@@ -287,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 
         private ScaleStatus GetScaleStatusCore(int workerCount, EventHubsTriggerMetrics[] metrics)
         {
-            ScaleStatus status = new ScaleStatus
+            var status = new ScaleStatus
             {
                 Vote = ScaleVote.None
             };

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubsTriggerMetrics.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubsTriggerMetrics.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Host.Scale;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
@@ -32,11 +32,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         /// <param name="client"></param>
         public EventHubAsyncCollector(EventHubClient client)
         {
-            if (client == null)
-            {
-                throw new ArgumentNullException("client");
-            }
-            _client = client;
+            _client = client ?? throw new ArgumentNullException(nameof(client));
         }
 
         /// <summary>
@@ -49,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         {
             if (item == null)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
             }
 
             string key = item.SystemProperties?.PartitionKey ?? string.Empty;
@@ -124,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             {
                 if (item == null)
                 {
-                    throw new ArgumentNullException("item");
+                    throw new ArgumentNullException(nameof(item));
                 }
 
                 while (true)

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             ParameterInfo parameter = context.Parameter;
@@ -75,16 +75,16 @@ namespace Microsoft.Azure.WebJobs.EventHubs
              (factoryContext, singleDispatch) =>
              {
                  IListener listener = new EventHubListener(
-                                                factoryContext.Descriptor.Id,
-                                                resolvedEventHubName,
-                                                resolvedConsumerGroup,
-                                                connectionString,
-                                                storageConnectionString,
-                                                factoryContext.Executor,
-                                                eventHostListener,
-                                                singleDispatch,
-                                                _options.Value,
-                                                _logger);
+                                                functionId: factoryContext.Descriptor.Id,
+                                                eventHubName: resolvedEventHubName,
+                                                consumerGroup: resolvedConsumerGroup,
+                                                connectionString: connectionString,
+                                                storageConnectionString: storageConnectionString,
+                                                executor: factoryContext.Executor,
+                                                eventProcessorHost: eventHostListener,
+                                                singleDispatch: singleDispatch,
+                                                options: _options.Value,
+                                                logger: _logger);
                  return Task.FromResult(listener);
              };
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInputBindingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInputBindingStrategy.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         public EventHubTriggerInput ConvertFromString(string input)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(input);
-            EventData eventData = new EventData(bytes);
+            var eventData = new EventData(bytes);
 
             // Return a single event. Doesn't support multiple dispatch 
             return EventHubTriggerInput.New(eventData);            
@@ -38,15 +38,18 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
+
             return value.Events;
         }
 
         public Dictionary<string, Type> GetBindingContract(bool isSingleDispatch = true)
         {
-            var contract = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
-            contract.Add("PartitionContext", typeof(PartitionContext));
+            var contract = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "PartitionContext", typeof(PartitionContext) }
+            };
 
             AddBindingContractMember(contract, "PartitionKey", typeof(string), isSingleDispatch);
             AddBindingContractMember(contract, "Offset", typeof(string), isSingleDispatch);
@@ -71,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubConfigurationTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Azure.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             for (int i = 0; i < 100; i++)
             {
-                List<EventData> events = new List<EventData>() { new EventData(new byte[0]) };
+                var events = new List<EventData>() { new EventData(new byte[0]) };
                 await eventProcessor.ProcessEventsAsync(partitionContext, events);
             }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             for (int i = 0; i < 100; i++)
             {
-                List<EventData> events = new List<EventData>() { new EventData(new byte[0]), new EventData(new byte[0]), new EventData(new byte[0]) };
+                var events = new List<EventData>() { new EventData(new byte[0]), new EventData(new byte[0]), new EventData(new byte[0]) };
                 await eventProcessor.ProcessEventsAsync(partitionContext, events);
             }
 
@@ -97,8 +97,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             checkpointer.Setup(p => p.CheckpointAsync(partitionContext)).Returns(Task.CompletedTask);
 
-            List<EventData> events = new List<EventData>();
-            List<FunctionResult> results = new List<FunctionResult>();
+            var events = new List<EventData>();
+            var results = new List<FunctionResult>();
             for (int i = 0; i < 10; i++)
             {
                 events.Add(new EventData(new byte[0]));
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             // ctor is private
             constructor = typeof(LeaseLostException)
                 .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(string), typeof(Exception) }, null);
-            LeaseLostException leaseLostEx = (LeaseLostException)constructor.Invoke(new object[] { "My LeaseLostException!", new Exception() });
+            var leaseLostEx = (LeaseLostException)constructor.Invoke(new object[] { "My LeaseLostException!", new Exception() });
 
             await eventProcessor.ProcessErrorAsync(partitionContext, leaseLostEx);
             msg = testLogger.GetLogMessages().Single();

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [InlineData("path2", "Endpoint=sb://test89123-ns-x.servicebus.windows.net/;SharedAccessKeyName=ReceiveRule;SharedAccessKey=secretkey;EntityPath=path2")]
         public void EntityPathInConnectionString(string expectedPathName, string connectionString)
         {
-            EventHubOptions options = new EventHubOptions();
+            var options = new EventHubOptions();
 
             // Test sender
             options.AddSender("k1", connectionString);
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [InlineData("path2", "Endpoint=sb://test89123-ns-x.servicebus.windows.net/;SharedAccessKeyName=ReceiveRule;SharedAccessKey=secretkey;EntityPath=path2")]
         public void GetEventHubClient_AddsConnection(string expectedPathName, string connectionString)
         {
-            EventHubOptions options = new EventHubOptions();
+            var options = new EventHubOptions();
             var client = options.GetEventHubClient("k1", connectionString);
             Assert.Equal(expectedPathName, client.EventHubName);
         }
@@ -214,8 +214,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [InlineData(200)]
         public void EventHubBatchCheckpointFrequency(int num)
         {
-            var options = new EventHubOptions();
-            options.BatchCheckpointFrequency = num;
+            var options = new EventHubOptions
+            {
+                BatchCheckpointFrequency = num
+            };
             Assert.Equal(num, options.BatchCheckpointFrequency);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubsScaleMonitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubsScaleMonitorTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
@@ -62,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [Fact]
         public async void CreateTriggerMetrics_ReturnsExpectedResult()
         {
-            EventHubsConnectionStringBuilder sb = new EventHubsConnectionStringBuilder(_eventHubConnectionString);
+            var sb = new EventHubsConnectionStringBuilder(_eventHubConnectionString);
             string prefix = $"{sb.Endpoint.Host}/{_eventHubName.ToLower()}/{_consumerGroup}/0";
 
             var mockBlobReference = new Mock<CloudBlockBlob>(MockBehavior.Strict, new Uri(_storageUri, $"{_eventHubContainerName}/{prefix}"));
@@ -134,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         [Fact]
         public async void CreateTriggerMetrics_MultiplePartitions_ReturnsExpectedResult()
         {
-            EventHubsConnectionStringBuilder sb = new EventHubsConnectionStringBuilder(_eventHubConnectionString);
+            var sb = new EventHubsConnectionStringBuilder(_eventHubConnectionString);
             string prefix = $"{sb.Endpoint.Host}/{_eventHubName.ToLower()}/{_consumerGroup}/";
 
             var mockBlobReference = new Mock<CloudBlockBlob>(MockBehavior.Strict, new Uri(_storageUri, $"{_eventHubContainerName}/{prefix}"));

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Reflection;
 using Xunit;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
Use var when type is obvious e.g. T variable = new T... and T variable = (T)...
Use object initializer when available.
Use nameof for input argument validation exceptions.
Use inline variable declaration now available in C# current version.
Use inline type matching pattern.
Normalized end of lines.
Use expression body for single line methods.
Consistent spacing after code block (curly end block bracket followed by new line).
Inline single-use variables.
Use expression null check pattern member =parameter ?? throw new ArgumentNullException
Removed unused using namespace declarations.