### PR TITLE
(AzureCXP) fixed eventhub size limit

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubAsyncCollector.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
               
         private const int BatchSize = 100;
 
-        // Suggested to use 240k instead of 256k to leave padding room for headers.
-        private const int MaxByteSize = 240 * 1024;
+        // Suggested to use 1008k instead of 1024k to leave padding room for headers.
+        private const int MaxByteSize = 1008 * 1024;
 
         private readonly ILogger _logger;
 


### PR DESCRIPTION
Line 29 has hardcoded value for event hub standard namespace where this should not be hardcoded as the basic event hub has a size limit of 256 KB whereas the standard and dedicated event hub has a size limit of 1 MB: https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas

Standard event hub size used to be 256 KB a few years back and that was changed to 1MB long time back. Either the logic needs to be updated to dynamically fetch the max size or this value needs to be updated.

As the validation is this piece of code if we are sending more than 240 KB data for Standard SKU then below error is observed.

2020-08-27T03:17:51.319 [Error,EventHubTriggerCSharp1] Exception while executing function: Functions.EventHubTriggerCSharp1. Microsoft.Azure.WebJobs.Host: Error while handling parameter outEventHubMessage after function returned:. Microsoft.Azure.WebJobs.ServiceBus: Event is too large. Event is approximately 999668b and max size is 245760b.
2020-08-27T03:17:51.366 [Error,EventHubTriggerCSharp1] Exception while executing function: Functions.EventHubTriggerCSharp1