### PR TITLE
change partion to partition(fix typo)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInput.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             return new Dictionary<string, string>()
             {
-                { "PartionId", context.PartitionId },
+                { "PartitionId", context.PartitionId },
                 { "Offset", offset },
                 { "EnqueueTimeUtc", enqueueTimeUtc },
                 { "SequenceNumber", sequenceNumber },


### PR DESCRIPTION
Fixing the "Partion" typo in EventhubTriggerInput.cs.
This resolves issue #87 