### PR TITLE
Stop Listener when disposed (#104)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 
 #### Version 4.3.1
 - Stop Listener when disposed [#105](https://github.com/Azure/azure-functions-eventhubs-extension/pull/105)
+- Add listener details [#105](https://github.com/Azure/azure-functions-eventhubs-extension/pull/105)

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,5 +5,8 @@
 #### Version 4.2.0
 -  User configurable initial offset support [#79](https://github.com/Azure/azure-functions-eventhubs-extension/pull/79)
 
-**Release sprint:** Sprint 87
-[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+87%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+87%22+label%3Afeature+is%3Aclosed) ]
+#### Version 4.3.0
+- Adding explicit reference Microsoft.Azure.Amqp 2.4.11 [#99](https://github.com/Azure/azure-functions-eventhubs-extension/pull/99)
+
+#### Version 4.3.1
+- Stop Listener when disposed [#105](https://github.com/Azure/azure-functions-eventhubs-extension/pull/105)

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private readonly EventHubOptions _options;
         private readonly ILogger _logger;
         private readonly SemaphoreSlim _stopSemaphoreSlim = new SemaphoreSlim(1, 1);
+        private readonly string _details;
         private bool _started;
-        private string _details;
 
         private Lazy<EventHubsScaleMonitor> _scaleMonitor;
 
@@ -94,6 +94,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 if (_started)
                 {
                     await _eventProcessorHost.UnregisterEventProcessorAsync();
+                    _logger.LogDebug($"EventHub listener stopped ({_details})");
+                }
+                else
+                {
+                    _logger.LogDebug($"EventHub listener is already stopped ({_details})");
                 }
                 _started = false;
             }
@@ -101,8 +106,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             {
                 _stopSemaphoreSlim.Release();
             }
-
-            _logger.LogDebug($"EventHub listener stopped ({_details})");
         }
 
         IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext context)

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.EventHubs</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.EventHubs</PackageId>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests/EventHubListenerTests.cs
@@ -199,7 +199,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var functionId = "FunctionId";
             var eventHubName = "EventHubName";
             var consumerGroup = "ConsumerGroup";
-            var storageUri = new Uri("https://eventhubsteststorageaccount.blob.core.windows.net/");
             var testLogger = new TestLogger("Test");
             var listener = new EventHubListener(
                                     functionId,
@@ -246,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                                     new Mock<CloudBlobContainer>(MockBehavior.Strict, new Uri("https://eventhubsteststorageaccount.blob.core.windows.net/azure-webjobs-eventhub")).Object);
 
             (listener as IDisposable).Dispose();
-            Assert.Single(testLogger.GetLogMessages().Where(x => x.FormattedMessage.StartsWith("EventHub listener stopped (")));
+            Assert.Single(testLogger.GetLogMessages().Where(x => x.FormattedMessage.StartsWith("EventHub listener is already stopped (")));
         }
     }
 }


### PR DESCRIPTION
Address issue detailed in #104

Also as part of the PR I added the track2 port (https://github.com/Azure/azure-functions-eventhubs-extension/pull/105/commits/6c9df8b30ccef9030095736ef65cade6cf61870d) which helps with `Dispose_Calls_StopAsync `test and CRIs invetigations in general:
https://github.com/Azure/azure-sdk-for-net/commit/bad9b8503e95c93b2641be2392b7512ac8335de2