### PR TITLE
Fix partition typo

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerInput.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             return new Dictionary<string, string>()
             {
-                { "PartionId", context.PartitionId },
+                { "PartitionId", context.PartitionId },
                 { "Offset", offset },
                 { "EnqueueTimeUtc", enqueueTimeUtc },
                 { "SequenceNumber", sequenceNumber },


### PR DESCRIPTION
Fixes #87 

P.S. I also checked the AppLens detector for EH, and it looks like it doesn't rely on the misspelled 'partion' keyword, rather it just looks for `parti*`, so this should continue to work fine :) 